### PR TITLE
Add support for pfUI and ShaguPlates

### DIFF
--- a/UIElements/nameplatesHandler.lua
+++ b/UIElements/nameplatesHandler.lua
@@ -3,6 +3,7 @@
 	local f = CreateFrame'Frame'
 	-------------------------------------------------------------------------------
 	local isPlate = function(frame)     
+		if frame and frame.nameplate then return true end
 		local overlayRegion = frame:GetRegions()
 		if not overlayRegion or overlayRegion:GetObjectType() ~= 'Texture'
 		or overlayRegion:GetTexture() ~= [[Interface\Tooltips\Nameplate-Border]] then
@@ -21,6 +22,7 @@
 	-------------------------------------------------------------------------------
 	local addRaidTarget = function(plate, n, raidTargets)
 		local _, _, name = plate:GetRegions()
+		name = plate.name or name
 		if not plate.raidTarget then
 			-- create killtarget icon
 			plate.raidTarget = plate:CreateTexture(nil, 'OVERLAY')
@@ -219,6 +221,7 @@
 			if isPlate(plate) and plate:IsVisible() then
 				local health = plate:GetChildren()
 				local _, _, name = plate:GetRegions()
+				name = plate.name or name
 				local n, h = name:GetText(), health:GetValue()
 				-- fills a list to help display accurate health values of enemies with visible plates
 				-- redudant to include target and mouseover units


### PR DESCRIPTION
Hi,

It might sound a bit selfish, but the ShaguPlates and pfUI-nameplates use a different layout which leads to the fact, that those are no longer be detected as nameplates by the enemeFrames scanner. 

Those changes on my plates were necessary to achive non-overlapping nameplates and the possiblilty to use the actual UIScale on those plates.

This PR adds support to detect those nameplates via a shortcut, as the pfUI- and ShaguPlates create a "nameplates" frame on the actual frame. It also tries to directly grab the name-frame if existing.

During my testing, there were no issue with default nameplates and this change should not affect those.

Cheers