### PR TITLE
add support for pfUI and ShaguPlates

### DIFF
--- a/UIElements/nameplatesHandler.lua
+++ b/UIElements/nameplatesHandler.lua
@@ -3,6 +3,7 @@
 	local f = CreateFrame'Frame'
 	-------------------------------------------------------------------------------
 	local isPlate = function(frame)     
+		if frame and frame.nameplate then return true end
 		local overlayRegion = frame:GetRegions()
 		if not overlayRegion or overlayRegion:GetObjectType() ~= 'Texture'
 		or overlayRegion:GetTexture() ~= [[Interface\Tooltips\Nameplate-Border]] then
@@ -13,7 +14,7 @@
 	-------------------------------------------------------------------------------
 	local addSmooth = function(plate)
 		if not plate.smooth then
-			local health = plate:GetChildren()
+			local health = plate.healthbar or plate:GetChildren()
 			SmoothBar(health)
 			plate.smooth = true
 		end
@@ -21,6 +22,7 @@
 	-------------------------------------------------------------------------------
 	local addRaidTarget = function(plate, n, raidTargets)
 		local _, _, name = plate:GetRegions()
+		name = plate.name or name
 		if not plate.raidTarget then
 			-- create killtarget icon
 			plate.raidTarget = plate:CreateTexture(nil, 'OVERLAY')
@@ -56,7 +58,7 @@
 	local BACKDROP = {bgFile = [[Interface\Tooltips\UI-Tooltip-Background]],}
 	local addCastbar = function(plate, name)
 		if not plate.castBar then
-			local health = plate:GetChildren()
+			local health = plate.healthbar or plate:GetChildren()
 			
 			plate.castBar = CreateFrame('StatusBar', nil, plate)
 			plate.castBar:SetStatusBarTexture(TEXTURE)
@@ -217,8 +219,9 @@
 		local frames = {WorldFrame:GetChildren()}
 		for _, plate in ipairs(frames) do
 			if isPlate(plate) and plate:IsVisible() then
-				local health = plate:GetChildren()
+				local health = plate.healthbar or plate:GetChildren()
 				local _, _, name = plate:GetRegions()
+				name = plate.name or name
 				local n, h = name:GetText(), health:GetValue()
 				-- fills a list to help display accurate health values of enemies with visible plates
 				-- redudant to include target and mouseover units


### PR DESCRIPTION
Hi,

the ShaguPlates and pfUI-nameplates use a different layout which leads to the fact, that those are no longer be detected as nameplates by the enemeFrames scanner.

Those changes on my plates were necessary to achive non-overlapping nameplates and the possiblilty to use the actual UIScale on those plates.

This PR adds support to detect those nameplates via a shortcut, as the pfUI- and ShaguPlates create a "nameplates" frame on the actual frame. It also tries to directly grab the name-frame if existing.

During my testing, there were no issue with default nameplates and this change does not affect those.

Cheers